### PR TITLE
chore(workflows): update test deploy workflow with SSH key auth and G…

### DIFF
--- a/.github/workflows/test-scp-upload.yml
+++ b/.github/workflows/test-scp-upload.yml
@@ -1,33 +1,68 @@
-name: Test SCP Upload
+name: Test Deploy
 
 on:
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   test-upload:
     runs-on: ubuntu-latest
     steps:
-      - name: Create test file
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch blog content
+        run: node scripts/fetch-blog-data.js
+        env:
+          BLOG_CONTENT_REPO_URL: https://github.com/xiaojingming/costrict-blog-content.git
+
+      - name: Build
+        run: pnpm build
+
+      - name: Archive dist
         run: |
-          echo "SCP upload test at $(date -u)" > test-upload.txt
+          cd dist
+          zip -r ../dist.zip .
+          tar -czf ../dist.tar.gz .
 
-      - name: SCP upload test
-        uses: appleboy/scp-action@v0.1.7
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          password: ${{ secrets.REMOTE_PASSWORD }}
-          source: test-upload.txt
-          target: /tmp/
+          tag_name: test-${{ github.run_id }}
+          draft: true
+          files: |
+            dist.zip
+            dist.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify on server
-        uses: appleboy/ssh-action@v1.0.0
-        with:
-          host: ${{ secrets.REMOTE_HOST }}
-          username: ${{ secrets.REMOTE_USER }}
-          password: ${{ secrets.REMOTE_PASSWORD }}
-          script: |
-            echo "=== Test upload result ==="
-            cat /tmp/test-upload.txt
-            rm /tmp/test-upload.txt
-            echo "=== SCP upload test passed ==="
+      - name: Deploy to remote server
+        if: success()
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/deploy_key -p ${{ secrets.SSH_PORT }} -o StrictHostKeyChecking=accept-new" \
+            dist/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.REMOTE_PATH }}
+
+      - name: Cleanup SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key


### PR DESCRIPTION
…itHub Release

Replace password-based SCP test with full build-deploy workflow matching blog-rebuild.yml, using SSH key + rsync for deployment and adding GitHub Release artifact upload.