### PR TITLE
fix(site): schedule August campaign banner updates

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,9 +24,10 @@
   },
   "home": {
     "augustBanner": {
-      "stage1Text": "CoStrict August Developer Month begins {'|'} User benefits upgrade is live",
-      "stage2Text": "CoStrict August Developer Month continues {'|'} Model ecosystem upgrade is live",
-      "stage3Text": "CoStrict August Developer Month {'|'} All three upgrades are now live",
+      "campaignName": "CoStrict August Developer Month",
+      "stage1Text": "Existing users receive an extra 20% Credits",
+      "stage2Text": "5 new models are now live",
+      "stage3Text": "All three upgrades are now live",
       "ariaLabel": "View CoStrict August Developer Month details"
     },
     "slogan": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -24,9 +24,10 @@
   },
   "home": {
     "augustBanner": {
-      "stage1Text": "CoStrict 8月开发者福利月开启｜用户权益升级已上线",
-      "stage2Text": "CoStrict 8月开发者福利月进行中｜模型生态升级已上线",
-      "stage3Text": "CoStrict 8月开发者福利月｜三大升级现已全部上线",
+      "campaignName": "CoStrict 8月开发者福利月",
+      "stage1Text": "老用户额外获赠20% Credits",
+      "stage2Text": "5大新模型已上线",
+      "stage3Text": "三大升级现已全部上线",
       "ariaLabel": "查看 CoStrict 8月开发者福利月详情"
     },
     "slogan": {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -59,9 +59,6 @@ export const routes = [
     path: '/operation/august-developer-month',
     name: 'augustDeveloperMonth',
     component: augustDeveloperMonthRoute.load,
-    meta: {
-      hideNavbar: true,
-    },
   },
   {
     path: '/operation/ccf-competition',

--- a/src/views/home/components/AugustDeveloperMonthBanner.vue
+++ b/src/views/home/components/AugustDeveloperMonthBanner.vue
@@ -1,10 +1,52 @@
 <script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { AUGUST_DEVELOPER_MONTH_PATH } from '@/views/operation/constants'
 
 defineOptions({ name: 'AugustDeveloperMonthBanner' })
 
 const { t } = useI18n()
+
+const STAGE_2_START = Date.parse('2026-08-05T00:00:00+08:00')
+const STAGE_3_START = Date.parse('2026-08-14T00:00:00+08:00')
+const MAX_TIMEOUT_MS = 2_147_483_647
+const now = ref(Date.now())
+let updateTimer: number | undefined
+
+const messageKey = computed(() => {
+  if (now.value >= STAGE_3_START) {
+    return 'home.augustBanner.stage3Text'
+  }
+
+  if (now.value >= STAGE_2_START) {
+    return 'home.augustBanner.stage2Text'
+  }
+
+  return 'home.augustBanner.stage1Text'
+})
+
+const scheduleNextMessage = () => {
+  const nextStart = [STAGE_2_START, STAGE_3_START].find((start) => start > now.value)
+
+  if (!nextStart) {
+    return
+  }
+
+  updateTimer = window.setTimeout(
+    () => {
+      now.value = Date.now()
+      scheduleNextMessage()
+    },
+    Math.min(nextStart - now.value, MAX_TIMEOUT_MS),
+  )
+}
+
+onMounted(scheduleNextMessage)
+onBeforeUnmount(() => {
+  if (updateTimer !== undefined) {
+    window.clearTimeout(updateTimer)
+  }
+})
 </script>
 
 <template>
@@ -16,7 +58,11 @@ const { t } = useI18n()
     :aria-label="t('home.augustBanner.ariaLabel')"
   >
     <span class="august-banner__content">
-      <span>{{ t('home.augustBanner.stage3Text') }}</span>
+      <span class="august-banner__copy">
+        <span>{{ t('home.augustBanner.campaignName') }}</span>
+        <span class="august-banner__separator" aria-hidden="true">｜</span>
+        <span>{{ t(messageKey) }}</span>
+      </span>
       <span class="august-banner__arrow" aria-hidden="true">→</span>
     </span>
   </RouterLink>
@@ -65,6 +111,16 @@ const { t } = useI18n()
   line-height: 1.5;
   letter-spacing: 0;
   text-align: center;
+}
+
+.august-banner__copy {
+  min-width: 0;
+}
+
+.august-banner__separator {
+  display: inline-block;
+  margin: 0 2px;
+  color: rgba(255, 255, 255, 0.42);
 }
 
 .august-banner__arrow {

--- a/src/views/operation/AugustDeveloperMonthPage.vue
+++ b/src/views/operation/AugustDeveloperMonthPage.vue
@@ -41,6 +41,7 @@ useHead({
 
 <style scoped lang="less">
 .august-campaign-page {
-  padding: 0;
+  box-sizing: border-box;
+  padding-top: var(--space-16);
 }
 </style>

--- a/src/views/operation/components/AugustDeveloperMonthSection.vue
+++ b/src/views/operation/components/AugustDeveloperMonthSection.vue
@@ -444,7 +444,7 @@ const capabilities = computed(() =>
 .campaign-detail-field {
   position: absolute;
   z-index: -1;
-  top: calc(100svh - 96px);
+  top: calc(100svh - var(--space-16) - 96px);
   right: 50%;
   bottom: 0;
   width: 100vw;
@@ -501,8 +501,8 @@ const capabilities = computed(() =>
 .campaign-hero {
   position: relative;
   display: flex;
-  min-height: 100vh;
-  min-height: 100svh;
+  min-height: calc(100vh - var(--space-16));
+  min-height: calc(100svh - var(--space-16));
   align-items: center;
   justify-content: center;
   flex-direction: column;

--- a/tests/unit/augustDeveloperMonthIntegration.spec.ts
+++ b/tests/unit/augustDeveloperMonthIntegration.spec.ts
@@ -34,7 +34,7 @@ describe('August Developer Month page integration', () => {
     window.history.replaceState({}, '', '/operation')
   })
 
-  it('renders the final activity banner before the homepage Hero', () => {
+  it('renders the scheduled activity banner before the homepage Hero', () => {
     const wrapper = shallowMount(HomeIndex, { global: { plugins: [i18n] } })
     const banner = wrapper.findComponent(AugustDeveloperMonthBanner)
     const hero = wrapper.findComponent({ name: 'SloganSection' })
@@ -119,7 +119,7 @@ describe('August Developer Month page integration', () => {
 
     expect(augustRoute).toBeDefined()
     expect(augustRoute?.name).toBe('augustDeveloperMonth')
-    expect(augustRoute?.meta.hideNavbar).toBe(true)
+    expect(augustRoute?.meta?.hideNavbar).not.toBe(true)
   })
 
   it('renders the complete standalone campaign without stage resolution or activity rows', async () => {
@@ -142,10 +142,13 @@ describe('August Developer Month page integration', () => {
     expect(wrapper.findAll('[data-activity-row]')).toHaveLength(0)
     expect(augustPageSource).not.toContain('resolveAugustDeveloperMonthStage')
     expect(augustPageSource).not.toContain('pt-16')
-    expect(augustPageSource).toContain('padding: 0')
+    expect(augustPageSource).toContain('padding-top: var(--space-16)')
   })
 
-  it('hides the global navigation on the standalone campaign route', () => {
+  it('shows the global navigation on the standalone campaign route', () => {
+    const augustRoute = routes.find((route) => route.path === '/operation/august-developer-month')
+
+    expect(augustRoute?.meta?.hideNavbar).not.toBe(true)
     expect(appSource).toContain('<navbar v-if="showNavbar" />')
     expect(appSource).toContain('route.meta.hideNavbar !== true')
   })

--- a/tests/unit/home/AugustDeveloperMonthBanner.spec.ts
+++ b/tests/unit/home/AugustDeveloperMonthBanner.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mount, RouterLinkStub } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import zh from '@/locales/zh.json'
@@ -22,25 +22,56 @@ const mountBanner = (locale: 'zh' | 'en') => {
 }
 
 describe('AugustDeveloperMonthBanner', () => {
-  it('always renders the final Chinese message and stage-free details route', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders the Credits message before August 5 and keeps the details route', () => {
+    vi.setSystemTime('2026-08-03T12:00:00+08:00')
     const wrapper = mountBanner('zh')
     const link = wrapper.findComponent(RouterLinkStub)
 
-    expect(wrapper.text()).toContain('CoStrict 8月开发者福利月｜三大升级现已全部上线')
+    expect(wrapper.text()).toContain('CoStrict 8月开发者福利月｜老用户额外获赠20% Credits')
     expect(link.props('to')).toBe('/operation/august-developer-month')
     expect(link.attributes('target')).toBe('_blank')
     expect(link.attributes('rel')).toBe('noopener noreferrer')
     expect(link.attributes('aria-label')).toBe('查看 CoStrict 8月开发者福利月详情')
-    expect(wrapper.text()).not.toContain('20%')
-    expect(wrapper.text()).not.toContain('Kimi')
-    expect(wrapper.text()).not.toContain('8月1日')
   })
 
-  it('always renders the final English message', () => {
+  it('switches to the model message at the August 5 Beijing-time cutoff', async () => {
+    vi.setSystemTime('2026-08-04T23:59:59+08:00')
+    const wrapper = mountBanner('zh')
+
+    expect(wrapper.text()).toContain('老用户额外获赠20% Credits')
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(wrapper.text()).toContain('CoStrict 8月开发者福利月｜5大新模型已上线')
+    expect(wrapper.text()).not.toContain('老用户额外获赠20% Credits')
+  })
+
+  it('switches to the final message at the August 14 Beijing-time cutoff', async () => {
+    vi.setSystemTime('2026-08-13T23:59:59+08:00')
+    const wrapper = mountBanner('zh')
+
+    expect(wrapper.text()).toContain('5大新模型已上线')
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(wrapper.text()).toContain('CoStrict 8月开发者福利月｜三大升级现已全部上线')
+    expect(wrapper.text()).not.toContain('5大新模型已上线')
+  })
+
+  it('renders the matching English message for the active stage', () => {
+    vi.setSystemTime('2026-08-06T12:00:00+08:00')
     const wrapper = mountBanner('en')
 
     expect(wrapper.text()).toContain(
-      'CoStrict August Developer Month | All three upgrades are now live',
+      'CoStrict August Developer Month｜5 new models are now live',
     )
   })
 })

--- a/tests/unit/operation/AugustDeveloperMonthSection.spec.ts
+++ b/tests/unit/operation/AugustDeveloperMonthSection.spec.ts
@@ -52,7 +52,7 @@ describe('AugustDeveloperMonthSection', () => {
     expect(monthStyles).toContain('width: 100%')
     expect(monthStyles).toContain('overflow-x: clip')
     expect(shellStyles).toContain('width: min(1120px, calc(100% - 48px))')
-    expect(heroStyles).toContain('min-height: 100svh')
+    expect(heroStyles).toContain('min-height: calc(100svh - var(--space-16))')
     expect(heroStyles).toContain('justify-content: center')
     expect(monthStyles).not.toContain('max-width: 960px')
     expect(benefitLayoutStyles).toContain(


### PR DESCRIPTION
## Summary

- Keep the August campaign name fixed on the homepage and pricing banners while scheduling the right-side message by Beijing time
- Show the Credits benefit now, switch to “5大新模型已上线” on August 5, and switch to the final upgrade message on August 14
- Restore the global website navigation on the standalone August campaign page
- Account for the fixed navbar height so the campaign hero remains vertically centered and unobstructed

## Verification

- `pnpm exec vitest run tests/unit/home/AugustDeveloperMonthBanner.spec.ts tests/unit/augustDeveloperMonthIntegration.spec.ts tests/unit/operation/AugustDeveloperMonthSection.spec.ts` (24 tests passed)
- `pnpm exec eslint ...` on all touched Vue/TypeScript files
- `pnpm type-check`
- `pnpm build-only`
- Browser-verified the homepage, pricing page, and standalone campaign page

## Notes

- The production build still reports the existing `resourceCalculator/index.vue` constant-assignment warning; this PR does not touch that file.
